### PR TITLE
Add of domain unionn, custom datatypes and remove of specific things

### DIFF
--- a/Chowlk_add.xml
+++ b/Chowlk_add.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mxfile host="app.diagrams.net" modified="2021-09-16T13:06:39.674Z" agent="5.0 (X11)" etag="X5qwtENCzjYXUD7FPgCx" version="15.2.7" type="google">
+  <diagram id="Ij0YYbhVVkDp38FKgO3t" name="Page-1">
+    <mxGraphModel dx="762" dy="1700" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-1" value="&lt;div style=&quot;font-size: 11px&quot;&gt;&lt;font style=&quot;font-size: 11px&quot;&gt;&lt;b&gt;base&lt;/b&gt;: http://base.namespace.com&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 11px&quot;&gt;&lt;font style=&quot;font-size: 11px&quot;&gt;&lt;b&gt;other:&lt;/b&gt; http://other.namespace.com&lt;br&gt;&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 11px&quot;&gt;&lt;div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 11px&quot;&gt;&lt;b&gt;rdf: &lt;/b&gt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&lt;b&gt;&lt;br&gt;&lt;/b&gt;&lt;/font&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 11px&quot;&gt;&lt;b&gt;rdfs: &lt;/b&gt;http://www.w3.org/2000/01/rdf-schema#&lt;br&gt;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 11px&quot;&gt;&lt;b&gt;owl: &lt;/b&gt;http://www.w3.org/2002/07/owl#&lt;br&gt;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 11px&quot;&gt;&lt;b&gt;xml:&lt;/b&gt; http://www.w3.org/XML/1998/namespace&lt;/font&gt;&lt;/div&gt;&lt;font style=&quot;font-size: 11px&quot;&gt;&lt;b&gt;xsd:&lt;/b&gt; http://www.w3.org/2001/XMLSchema#&lt;/font&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 11px&quot;&gt;&lt;b&gt;dc:&lt;/b&gt; http://purl.org/dc/elements/1.1/&lt;/font&gt;&lt;/div&gt;&lt;/div&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 11px&quot;&gt;&lt;b&gt;skos&lt;/b&gt;: http://www.w3.org/2004/02/skos/core#&lt;b&gt;&lt;br&gt;&lt;/b&gt;&lt;/font&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 11px&quot;&gt;&lt;b&gt;time: &lt;/b&gt;http://www.w3.org/2006/time#&lt;br&gt;&lt;b&gt;&lt;b&gt;mnx: &lt;/b&gt;&lt;/b&gt;&lt;span&gt;http://ns.mnemotix.com/ontologies/2019/8/generic-model/&lt;/span&gt;&lt;/font&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 11px&quot;&gt;&lt;b&gt;prov:&lt;/b&gt; http://www.w3.org/ns/prov#&lt;/font&gt;&lt;/div&gt;&lt;/div&gt;" style="shape=note;whiteSpace=wrap;html=1;backgroundOutline=1;darkOpacity=0.05;" vertex="1" parent="1">
+          <mxGeometry x="180" y="-100" width="300" height="260" as="geometry" />
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-2" value="&lt;div&gt;&lt;b&gt;dc:creator:&lt;/b&gt;&amp;nbsp;Full Name&lt;/div&gt;&lt;div&gt;&lt;b&gt;owl:versionInfo:&lt;/b&gt; 0.0.1&lt;/div&gt;&lt;div&gt;&lt;b&gt;dc:title:&lt;/b&gt; Template Ontology&lt;/div&gt;" style="shape=document;whiteSpace=wrap;html=1;boundedLbl=1;labelBackgroundColor=#ffffff;strokeColor=#000000;fontSize=12;fontColor=#000000;size=0.23333333333333334;" vertex="1" parent="1">
+          <mxGeometry x="208.5" y="190" width="253" height="90" as="geometry" />
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-6" value="ns:Class3" style="rounded=0;whiteSpace=wrap;html=1;snapToPoint=1;points=[[0.1,0],[0.2,0],[0.3,0],[0.4,0],[0.5,0],[0.6,0],[0.7,0],[0.8,0],[0.9,0],[0,0.1],[0,0.3],[0,0.5],[0,0.7],[0,0.9],[0.1,1],[0.2,1],[0.3,1],[0.4,1],[0.5,1],[0.6,1],[0.7,1],[0.8,1],[0.9,1],[1,0.1],[1,0.3],[1,0.5],[1,0.7],[1,0.9]];" vertex="1" parent="1">
+          <mxGeometry x="208.5" y="465" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-8" value="ns:datatypeProperty1: xsd:int" style="rounded=0;whiteSpace=wrap;html=1;snapToPoint=1;points=[[0.1,0],[0.2,0],[0.3,0],[0.4,0],[0.5,0],[0.6,0],[0.7,0],[0.8,0],[0.9,0],[0,0.1],[0,0.3],[0,0.5],[0,0.7],[0,0.9],[0.1,1],[0.2,1],[0.3,1],[0.4,1],[0.5,1],[0.6,1],[0.7,1],[0.8,1],[0.9,1],[1,0.1],[1,0.3],[1,0.5],[1,0.7],[1,0.9]];" vertex="1" parent="1">
+          <mxGeometry x="208.5" y="495" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-10" value="&lt;span class=&quot;st&quot;&gt;⨆&lt;/span&gt;" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fontSize=17;" vertex="1" parent="1">
+          <mxGeometry x="620" y="465" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-11" value="ns:Class1" style="rounded=0;whiteSpace=wrap;html=1;snapToPoint=1;points=[[0.1,0],[0.2,0],[0.3,0],[0.4,0],[0.5,0],[0.6,0],[0.7,0],[0.8,0],[0.9,0],[0,0.1],[0,0.3],[0,0.5],[0,0.7],[0,0.9],[0.1,1],[0.2,1],[0.3,1],[0.4,1],[0.5,1],[0.6,1],[0.7,1],[0.8,1],[0.9,1],[1,0.1],[1,0.3],[1,0.5],[1,0.7],[1,0.9]];" vertex="1" parent="1">
+          <mxGeometry x="687" y="440" width="100" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-12" value="ns:Class2" style="rounded=0;whiteSpace=wrap;html=1;snapToPoint=1;points=[[0.1,0],[0.2,0],[0.3,0],[0.4,0],[0.5,0],[0.6,0],[0.7,0],[0.8,0],[0.9,0],[0,0.1],[0,0.3],[0,0.5],[0,0.7],[0,0.9],[0.1,1],[0.2,1],[0.3,1],[0.4,1],[0.5,1],[0.6,1],[0.7,1],[0.8,1],[0.9,1],[1,0.1],[1,0.3],[1,0.5],[1,0.7],[1,0.9]];" vertex="1" parent="1">
+          <mxGeometry x="687" y="490" width="100" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-13" value="" style="endArrow=open;html=1;fontColor=#000099;exitX=1;exitY=0;exitDx=0;exitDy=0;endFill=0;dashed=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;endSize=8;arcSize=0;" edge="1" source="kBuUUooIwrNTVMl0dgkI-10" target="kBuUUooIwrNTVMl0dgkI-11" parent="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="472" y="490" as="sourcePoint" />
+            <mxPoint x="630" y="490" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-14" value="" style="endArrow=open;html=1;fontColor=#000099;exitX=1;exitY=1;exitDx=0;exitDy=0;endFill=0;dashed=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;endSize=8;arcSize=0;" edge="1" source="kBuUUooIwrNTVMl0dgkI-10" target="kBuUUooIwrNTVMl0dgkI-12" parent="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="655.6066017177982" y="479.3933982822018" as="sourcePoint" />
+            <mxPoint x="697" y="465" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-17" value="" style="endArrow=classic;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;endSize=8;arcSize=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="kBuUUooIwrNTVMl0dgkI-10" target="kBuUUooIwrNTVMl0dgkI-6" parent="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="489" y="635" as="sourcePoint" />
+            <mxPoint x="580" y="510" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-18" value="&lt;div&gt;ns:objectProperty1&lt;/div&gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];labelBackgroundColor=#ffffff;" vertex="1" connectable="0" parent="kBuUUooIwrNTVMl0dgkI-17">
+          <mxGeometry x="-0.1269" relative="1" as="geometry">
+            <mxPoint x="4.17" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-19" value="&lt;div style=&quot;font-size: 13px&quot;&gt;&lt;font style=&quot;font-size: 13px&quot;&gt;base:customDatatatype1&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 13px&quot;&gt;&lt;div&gt;&lt;font style=&quot;font-size: 13px&quot;&gt;base:customDatatatype2&lt;/font&gt;&lt;/div&gt;&lt;/div&gt;" style="shape=parallelogram;perimeter=parallelogramPerimeter;whiteSpace=wrap;html=1;fixedSize=1;" vertex="1" parent="1">
+          <mxGeometry x="577" y="120" width="243" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-20" value="ns:datatypeProperty2: base:customDatatype1" style="rounded=0;whiteSpace=wrap;html=1;snapToPoint=1;points=[[0.1,0],[0.2,0],[0.3,0],[0.4,0],[0.5,0],[0.6,0],[0.7,0],[0.8,0],[0.9,0],[0,0.1],[0,0.3],[0,0.5],[0,0.7],[0,0.9],[0.1,1],[0.2,1],[0.3,1],[0.4,1],[0.5,1],[0.6,1],[0.7,1],[0.8,1],[0.9,1],[1,0.1],[1,0.3],[1,0.5],[1,0.7],[1,0.9]];" vertex="1" parent="1">
+          <mxGeometry x="208.5" y="525" width="180" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-21" value="&lt;div&gt;&amp;lt;&amp;lt;owl:ObjectProperty&amp;gt;&amp;gt; ns:objectProperty2&lt;br&gt;&lt;/div&gt;" style="rhombus;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="470" y="290" width="180" height="75" as="geometry" />
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-23" value="&lt;div&gt;ns:Class4&lt;/div&gt;" style="rounded=0;whiteSpace=wrap;html=1;snapToPoint=1;points=[[0.1,0],[0.2,0],[0.3,0],[0.4,0],[0.5,0],[0.6,0],[0.7,0],[0.8,0],[0.9,0],[0,0.1],[0,0.3],[0,0.5],[0,0.7],[0,0.9],[0.1,1],[0.2,1],[0.3,1],[0.4,1],[0.5,1],[0.6,1],[0.7,1],[0.8,1],[0.9,1],[1,0.1],[1,0.3],[1,0.5],[1,0.7],[1,0.9]];" vertex="1" parent="1">
+          <mxGeometry x="380" y="400" width="120" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-24" value="" style="endArrow=open;html=1;fontColor=#000099;endFill=0;dashed=1;endSize=8;arcSize=0;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="kBuUUooIwrNTVMl0dgkI-21" target="kBuUUooIwrNTVMl0dgkI-23" parent="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="545" y="360" as="sourcePoint" />
+            <mxPoint x="410" y="413.75" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-25" value="&lt;div&gt;&amp;lt;&amp;lt;rdfs:range&amp;gt;&amp;gt;&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="kBuUUooIwrNTVMl0dgkI-24">
+          <mxGeometry x="-0.3525" y="-1" relative="1" as="geometry">
+            <mxPoint x="7.82" y="5.56" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-26" value="" style="endArrow=open;html=1;fontColor=#000099;endFill=0;dashed=1;endSize=8;arcSize=0;exitX=1;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="kBuUUooIwrNTVMl0dgkI-21" target="kBuUUooIwrNTVMl0dgkI-10" parent="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="580" y="380" as="sourcePoint" />
+            <mxPoint x="590" y="440" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kBuUUooIwrNTVMl0dgkI-27" value="&lt;div&gt;&amp;lt;&amp;lt;rdfs:domain&amp;gt;&amp;gt;&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="kBuUUooIwrNTVMl0dgkI-26">
+          <mxGeometry x="-0.055" y="2" relative="1" as="geometry">
+            <mxPoint x="-1" as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/source/chowlk/associations.py
+++ b/source/chowlk/associations.py
@@ -128,7 +128,7 @@ def individual_type_identification(individuals, associations, relations):
 
 
 
-def enrich_properties(rhombuses, relations, attribute_blocks):
+def enrich_properties(rhombuses, relations, attribute_blocks, concepts):
 
     relations_byname = {relation["uri"]: id for id, relation in relations.items() if "uri" in relation}
     attributes_byname = {attribute["uri"]: [id, idx] for id, attribute_block in attribute_blocks.items()
@@ -179,6 +179,9 @@ def enrich_properties(rhombuses, relations, attribute_blocks):
                     sprop_id = attributes_byname[sprop_name][0]
                     sprop_idx = attributes_byname[sprop_name][1]
                     attribute_blocks[sprop_id]["attributes"][sprop_idx][type] = target_id
+                    
+                    if type == "range":
+                        attribute_blocks[sprop_id]["attributes"][sprop_idx]["datatype"] = concepts[target_id]["prefix"] + ":" + concepts[target_id]["label"]
 
 
     for rhombus_id, rhombus in rhombuses.items():

--- a/source/chowlk/finding.py
+++ b/source/chowlk/finding.py
@@ -55,7 +55,7 @@ class Finder():
                 # Looking for ellipses in a second iteration
                 for child2 in self.root:
                     style2 = child2.attrib["style"] if "style" in child2.attrib else ""
-                    if source == child2.attrib["id"] and "ellipse" in style2:
+                    if source == child2.attrib["id"] and "ellipse" in style2 and "open" in style:
                         # This edge is part of a unionOf / intersectionOf construct
                         # it is not useful beyond that construction
                         relation["type"] = "ellipse_connection"
@@ -267,7 +267,27 @@ class Finder():
                         continue
 
         return self.ontology_metadata
+    
+    ######################################
+    # Possibily to add custom datatypes
 
+    def find_datatypes(self):
+
+        for child in self.root:
+
+            style = child.attrib["style"] if "style" in child.attrib else ""
+            value = child.attrib["value"] if "value" in child.attrib else ""
+
+            if "shape=parallelogram" in style:
+                text = clean_html_tags(value)
+                datatypes = text.split("|")
+                print(datatypes)
+                self.ontology_datatypes = datatypes
+                break
+            else: 
+                self.ontology_datatypes = []
+
+        return self.ontology_datatypes
 
     def find_ellipses(self):
 
@@ -583,8 +603,8 @@ class Finder():
                             
                             try:
                                 if len(attribute_value.split(":")) > 2:
-                                    final_datatype = attribute_value.split(":")[2].strip()
-                                    final_datatype = final_datatype[0].lower() + final_datatype[1:]
+                                    final_datatype = attribute_value.split(" ")[1].strip()
+
                                     attribute["datatype"] = final_datatype
                                 else:
                                     attribute["datatype"] = None
@@ -741,10 +761,11 @@ class Finder():
 
         namespaces = self.find_namespaces()
         metadata = self.find_metadata()
+        datatypes = self.find_datatypes()
         relations = self.find_relations()
         ellipses = self.find_ellipses()
         individuals = self.find_individuals()
         concepts, attribute_blocks = self.find_concepts_and_attributes()
         rhombuses, errors = self.find_rhombuses()
 
-        return concepts, attribute_blocks, relations, individuals, ellipses, metadata, namespaces, rhombuses, errors
+        return concepts, attribute_blocks, datatypes, relations, individuals, ellipses, metadata, namespaces, rhombuses, errors

--- a/source/chowlk/transformations.py
+++ b/source/chowlk/transformations.py
@@ -8,10 +8,10 @@ import os
 
 def transform_ontology(root):
     finder = Finder(root)
-    concepts, attribute_blocks, relations, individuals, anonymous_concepts, metadata, namespaces, rhombuses, errors = finder.find_elements()
+    concepts, attribute_blocks, datatypes, relations, individuals, anonymous_concepts, metadata, namespaces, rhombuses, errors = finder.find_elements()
     values = finder.find_attribute_values()
     prefixes_identified = find_prefixes(concepts, relations, attribute_blocks, individuals)
-    relations, attribute_blocks = enrich_properties(rhombuses, relations, attribute_blocks)
+    relations, attribute_blocks = enrich_properties(rhombuses, relations, attribute_blocks, concepts)
     attribute_blocks = resolve_concept_reference(attribute_blocks, concepts)
     associations = concept_attribute_association(concepts, attribute_blocks)
     associations, relations = concept_relation_association(associations, relations)
@@ -23,6 +23,7 @@ def transform_ontology(root):
 
     file, onto_prefix, onto_uri, new_namespaces = get_ttl_template(namespaces, prefixes_identified)
     file = write_ontology_metadata(file, metadata, onto_uri)
+    file = write_ontology_datatypes(file, datatypes)
     file = write_object_properties(file, relations, concepts, anonymous_concepts, attribute_blocks)
     file = write_data_properties(file, attribute_blocks, concepts)
     file = write_concepts(file, concepts, anonymous_concepts, associations)


### PR DESCRIPTION
Hi,
I add the possibility to add custom datatypes into Chowlk by using Parallelogram.
I add too the possibility to create domain union for properties.
There are some of you choose I'm not into. First, xsd is forced as default namespace for datatype and name with first lower letter.There are default datatypes that not worked with this rules like rdfs:Literal or even xsd:Name. It not works either with custom datatypes so I have to removed it. I removed also default labels because I write them in another development phase. i removed also the default namespace, i prefered to see them but it really a personal point of view.

Another problem I saw in the last updates. The turtle file and xml are not organise as before with a specific order and with big title comment title in the files. It was a good things and it would be great to get it back. 

I add a xml_file you can import on Draw.Io to see the modifications.
Please feel free to send me any remarks, questions or suggestions.